### PR TITLE
Fixed "headerShown" Typo in Navigation.js

### DIFF
--- a/src/Navigator/Navigation.js
+++ b/src/Navigator/Navigation.js
@@ -6,12 +6,12 @@ import Login from '../Screens/Login';
 import UserInfo from '../Screens/UserInfo';
 import ForgetPassword from '../Screens/ForgetPassword';
 const AuthStack=createStackNavigator();
-const StackScreens=({ navigation})=>(
+const StackScreens=({navigation})=>(
     <AuthStack.Navigator screenOptions={{headerShown:false}} initialRouteName="SignUp">
-        <AuthStack.Screen name="SignUp" component={Signup} options={{headershown:false}}/>
-        <AuthStack.Screen name="Login" component={Login} options={{headershown:false}}/> 
-        <AuthStack.Screen name="User" component={UserInfo} options={{headershown:false}}/>   
-        <AuthStack.Screen name="ForgetPassword" component={ForgetPassword} options={{headershown:false}}/>   
+        <AuthStack.Screen name="SignUp" component={Signup} options={{headerShown:false}}/>
+        <AuthStack.Screen name="Login" component={Login} options={{headerShown:false}}/> 
+        <AuthStack.Screen name="User" component={UserInfo} options={{headerShown:false}}/>   
+        <AuthStack.Screen name="ForgetPassword" component={ForgetPassword} options={{headerShown:false}}/>   
    
     </AuthStack.Navigator>
 )


### PR DESCRIPTION
The header property in options must be typed with an upper case S "headerShown" similar to line 10.